### PR TITLE
Fix failure for multiple interfaces

### DIFF
--- a/worker/windows/install_ovn.ps1
+++ b/worker/windows/install_ovn.ps1
@@ -16,7 +16,7 @@ Start-Service docker
 
 docker network create -d transparent --gateway $GATEWAY_IP --subnet $SUBNET -o com.docker.network.windowsshim.interface=$INTERFACE_ALIAS external
 
-$a = Get-NetAdapter
+$a = Get-NetAdapter | where Name -Match HNSTransparent
 rename-netadapter $a[0].name -newname HNSTransparent
 
 stop-service ovs-vswitchd; disable-vmswitchextension "cloudbase open vswitch extension";


### PR DESCRIPTION
If there are multiple interfaces on the host, the command `Get-NetAdapter`
will retrieve all the interface on the host.

The following command `rename-netadapter` relies on the fact that the variable
`a` will have only the docker created interface.

This patch adds matching on `Get-NetAdapter` to the docker generated interface.

Signed-off-by: Alin Gabriel Serdean <aserdean@cloudbasesolutions.com>